### PR TITLE
Date selection

### DIFF
--- a/client/app/scripts/controllers/buildingDisplay.js
+++ b/client/app/scripts/controllers/buildingDisplay.js
@@ -16,7 +16,7 @@ angular.module('clientApp')
       $scope.options = {
         chart: {
           type: 'lineWithFocusChart',
-          height: 500,
+          height: 600,
           margin: {
             top: 30,
             right: 75,
@@ -61,18 +61,6 @@ angular.module('clientApp')
         if (!savedData[resourceType]) {
           getBuildingData();
         }
-        createGraphData(savedData[resourceType]);
-        switch (selectedResource) {
-          case 2:
-                $scope.options.chart.yAxis.axisLabel = 'Electricity';
-                break;
-          case 3:
-                $scope.options.chart.yAxis.axisLabel = 'Gas';
-                break;
-          default:
-                $scope.options.chart.yAxis.axisLabel = 'Whatever';
-                break;
-        }
       };
 
       function createGraphData(data){
@@ -88,11 +76,10 @@ angular.module('clientApp')
       function getBuildingData() {
         //if going to building page directly or refreshing, steal name from url (basically a hack)
         if ($scope.selectedBuilding === 'DESELECTED') {
-          $scope.selectedBuilding = {};
-          $scope.selectedBuilding.name = $location.path().replace('/buildings/', '').replace('--', '/');
+          var tempName = $location.path().replace('/buildings/', '').replace('--', '/');
 
           //get resource info for building from name rather than ID
-          buildingSvc.getBuildingDataFromName($scope.selectedBuilding.name, selectedResource).then(function (data) {
+          buildingSvc.getBuildingDataFromName(tempName, selectedResource).then(function (data) {
             initGraph(data);
           });
         }
@@ -110,5 +97,36 @@ angular.module('clientApp')
       function initGraph(data) {
         savedData[selectedResource] = data;
         createGraphData(data);
+        setResourceLabel();
+        setFocusArea();
+      }
+
+      function setResourceLabel() {
+        switch (selectedResource) {
+          case 2:
+            $scope.options.chart.yAxis.axisLabel = 'Electricity';
+            break;
+          case 3:
+            $scope.options.chart.yAxis.axisLabel = 'Gas';
+            break;
+          default:
+            $scope.options.chart.yAxis.axisLabel = 'Whatever';
+            break;
+        }
+      }
+
+      //sets initial "zoom" view over specified area
+      function setFocusArea() {
+        //creating focus coordinates
+        var curDate = new Date();
+        var prevDate = new Date();
+        prevDate.setMonth(prevDate.getMonth() - 1);
+
+        //not sure why we have to wait...
+        setTimeout(function () {
+          var chart = $scope.api.getScope().chart;  //get chart from view
+          chart.brushExtent([prevDate, curDate]);
+          $scope.api.update();
+        }, 500);
       }
   });

--- a/client/app/scripts/controllers/buildingDisplay.js
+++ b/client/app/scripts/controllers/buildingDisplay.js
@@ -2,7 +2,6 @@
 
 angular.module('clientApp')
   .controller('BuildingDisplayCtrl', function ($scope, $location, buildingSvc) {
-      var monthlyView = false; //when changing between monthly and daily tables?
       var selectedResource = 2; //default resource
       var savedData = [];  //save downloaded data to avoid downloading
       $scope.selectedBuilding = buildingSvc.getSelectedBuilding();
@@ -16,7 +15,7 @@ angular.module('clientApp')
 
       $scope.options = {
         chart: {
-          type: 'lineChart',
+          type: 'lineWithFocusChart',
           height: 500,
           margin: {
             top: 30,
@@ -29,12 +28,13 @@ angular.module('clientApp')
             axisLabel: 'Time',
             showMaxMin: false,
             tickFormat: function(d) {
-              if (monthlyView) {
-                return d3.time.format('%m/%y')(new Date(d))
-              }
-              else {
-                return d3.time.format('%m/%d/%y')(new Date(d))
-              }
+              return d3.time.format('%m/%d/%y')(new Date(d));
+            }
+          },
+          x2Axis: {
+            showMaxMin: false,
+            tickFormat: function(d) {
+              return d3.time.format('%m/%y')(new Date(d));
             }
           },
           yAxis: {
@@ -43,10 +43,14 @@ angular.module('clientApp')
             axisLabelDistance: 25,
             tickPadding: [10]
           },
+          y2Axis: {
+            tickValues: 0,
+            showMaxMin: false
+          },
           lines: {
             forceY: [0]
           },
-          transitionDuration: 250
+          transitionDuration: 500
         }
       };
 
@@ -89,8 +93,7 @@ angular.module('clientApp')
 
           //get resource info for building from name rather than ID
           buildingSvc.getBuildingDataFromName($scope.selectedBuilding.name, selectedResource).then(function (data) {
-            savedData[selectedResource] = data;
-            createGraphData(data);
+            initGraph(data);
           });
         }
 
@@ -98,9 +101,14 @@ angular.module('clientApp')
         else {
           //get resource info for building
           buildingSvc.getBuildingData($scope.selectedBuilding.id, selectedResource).then(function (data) {
-            savedData[selectedResource] = data;
-            createGraphData(data);
+            initGraph(data);
           });
         }
+      }
+
+      //called once data is retrieved
+      function initGraph(data) {
+        savedData[selectedResource] = data;
+        createGraphData(data);
       }
   });

--- a/client/app/views/buildingDisplay.html
+++ b/client/app/views/buildingDisplay.html
@@ -10,7 +10,7 @@
   <div class="col-md-9" id="graph">
     <h1>{{selectedBuilding.name}}</h1>
     <div>
-      <nvd3 options='options' data='data'></nvd3>
+      <nvd3 options='options' data='data' api="api"></nvd3>
     </div>
   </div>
 

--- a/client/bower.json
+++ b/client/bower.json
@@ -14,7 +14,7 @@
     "angular-route": "~1.2.0",
     "lodash": "~2.4.1",
     "restangular": "~1.4.0",
-    "angular-nvd3": "~0.0.9"
+    "angular-nvd3": "git://github.com/krispo/angular-nvd3.git#master"
   },
   "devDependencies": {
     "angular-mocks": "~1.2.0",


### PR DESCRIPTION
NVD3 has a graph type called lineWithFocusChart that already has a built in slider for the x axis.  I thought this would be an easy and visually appealing way to implement our date selector (feel free to disagree).

Once the building display opens, a focus area of the past month is automatically selected, since we are using old data, this sort of breaks, but should work once we are pulling in new data every day.

These changes required features that were only available in the newest unreleased version of the angular-nvd3 directive so I had to update the bower module.  So after pushing this, you will need to do a <b>bower update angular-nvd3</b>

There are also a few random other bugfixes that I somehow missed before.