### PR TITLE
Optimization for resource toggling

### DIFF
--- a/client/app/scripts/controllers/buildingDisplay.js
+++ b/client/app/scripts/controllers/buildingDisplay.js
@@ -57,9 +57,7 @@ angular.module('clientApp')
       $scope.selectResource = function (resourceType) {
         resetData();
         selectedResource = resourceType;
-        for(var i = 0; i < $scope.selectedBuildings.length; i++) {
-          getBuildingData(i);
-        }
+        getBuildingData();
       };
 
       //when date inputs have been changed


### PR DESCRIPTION
Following @dkaai suggestion.  getBuildingData already loops over the buildings, we don't need to do it again in selectResource.