### PR TITLE
Knobs: more helpful no data message

### DIFF
--- a/client/app/scripts/directives/knob.js
+++ b/client/app/scripts/directives/knob.js
@@ -37,7 +37,13 @@ angular.module('clientApp').directive('knob', function() {
         fgColor : fgColor,
         readOnly: "true", //hardcoded, sorry
         rtl : (attr.dir == 'rtl'),
-        draw : function () { $(this.i).val(this.cv + sign); }
+        draw : function () {
+          //if no data, print message rather than NaN
+          if (isNaN(val))
+            $(this.i).val("N/A");
+          else
+            $(this.i).val(this.cv + sign);
+        }
       };
       tmpl.knob(options);
 


### PR DESCRIPTION
There is no water data, so the water knob displayed NaN which looks kinda bad.
This now displays a new message.  There is much room to display text so I changed it to "N/A".  Change it to something else if you like.